### PR TITLE
Cleanup the test-all-scream action

### DIFF
--- a/.github/actions/test-all-scream/README.md
+++ b/.github/actions/test-all-scream/README.md
@@ -1,40 +1,30 @@
 # Composite action to call test-all-scream inside a workflow
 
-This action is meant to be used inside a workflow as
+This action is meant to be used inside a workflow. E.g.,
 
-  steps:
-    ...
-    - name: run-test-all-scream
-      uses: ./.github/actions/eamxx-test-all-scream
-      with:
-        build_type: <build-type>
-        device: <device>
-        run_type: <run-type>
+jobs:
+  my-testing:
+    steps:
+      ...
+      - name: run-test-all-scream
+        uses: ./.github/actions/eamxx-test-all-scream
+        with:
+          build_type: <build-type>
+          machine: <machine>
+          run_type: <run-type>
 
-The three parameters have the following valid values:
+The input run_type is the only input that this action has to explicitly handle.
+As such, this action checks that its value is one of the following.
 
-build_type:
- - sp: single-precision debug build
- - dbg: double-precision debug build
- - fpe: double-precision debug build, with FPE enabled
- - opt: double-precision release build
- - valg: double-precision debug build with valgrind memory check
- - csm: double-precision debug build with cuda compute-sanitizer --tool memcheck
- - csi: double-precision debug build with cuda compute-sanitizer --tool initcheck
- - csr: double-precision debug build with cuda compute-sanitizer --tool racecheck
- - csi: double-precision debug build with cuda compute-sanitizer --tool initcheck
-
-device:
- - openmp: Kokkos::OpenMP backend
- - serial: Kokkos::Serial backend
- - cuda: Kokkos::Cuda backend
- - hip: Kokkos::HIP backend
-
-run_type:
  - nightly: runs tests and then submit to cdash
  - at-run: runs tests without submitting to cdash
  - bless: runs tests and copy output files to baselines folder
 
-All the tests will run with a machine called "ghci-snl-$device". Please, make sure
-that you added a machine file ghci-snl-$device.cmake in components/eamxx/cmake/machine-files,
-as well as an entry for ghci-snl-$device in components/eamxx/scripts/machine_specs.py.
+As for build_type and machine, we do not prescribe a list of
+valid values, as that will be handled by components/eamxx/scripts/test-all-scream.
+If their values are not supported, it is up to test-all-scram to handle the error.
+As a guideline, however, you may have to ensure that the following exist:
+ - the file components/eamxx/cmake/machine-files/${machine}.cmake
+ - the entry ${machine} in the MACHINE_METADATA dict in components/eamxx/scripts/machine_specs.py
+
+ Questions? Contact Luca Bertagna (lbertag@sandia.gov)

--- a/.github/actions/test-all-scream/action.yml
+++ b/.github/actions/test-all-scream/action.yml
@@ -5,52 +5,19 @@ inputs:
   build_type:
     description: 'Build type to run'
     required: true
-    # type: string
-    # options: [sp, dbg, fpe, opt, cov, valg, csm, css, csr, csi]
-  # compiler:
-  #   description: 'Compiler to use'
-  #   required: true
-  #   type: string
-  #   options: [gcc, intel, cuda]
-  device:
-    description: 'Kokkos device to use'
+  machine:
+    description: 'Machine name for test-all-scream'
     required: true
-    # type: string
-    # options: [serial, openmp, cuda]
-  run-type:
+  run_type:
     description: 'Type of test-all-scream run'
     required: true
-    # type: string
-    # options: [nightly, at-run, bless]
 
 runs:
   using: "composite"
   steps:
     - name: Validate inputs
       run: |
-        VALID_BUILD_TYPES="sp dbg fpe opt cov valg csm css csr csi"
-        VALID_COMPILERS="gcc intel cuda"
-        VALID_DEVICES="serial openmp cuda"
         VALID_RUN_TYPES="nightly at-run bless"
-
-        if ! [[ " $VALID_BUILD_TYPES " =~ " ${{ inputs.build_type }} " ]]; then
-          echo "Invalid build_type: ${{ inputs.build_type }}"
-          echo "Valid choices: $VALID_BUILD_TYPES"
-          exit 1
-        fi
-
-        if ! [[ " $VALID_COMPILERS " =~ " ${{ inputs.compiler }} " ]]; then
-          echo "Invalid compiler: ${{ inputs.compiler }}"
-          echo "Valid choices: $VALID_COMPILERS"
-          exit 1
-        fi
-
-        if ! [[ " $VALID_DEVICES " =~ " ${{ inputs.device }} " ]]; then
-          echo "Invalid device: ${{ inputs.device }}"
-          echo "Valid choices: $VALID_DEVICES"
-          exit 1
-        fi
-
         if ! [[ " $VALID_RUN_TYPES " =~ " ${{ inputs.run_type }} " ]]; then
           echo "Invalid run_type: ${{ inputs.run_type }}"
           echo "Valid choices: $VALID_RUN_TYPES"
@@ -62,67 +29,27 @@ runs:
           echo "Repository is not checked out. Please ensure the repository is checked out before running this action."
           exit 1
         fi
-    - name: Set long-name based on build_type
-      id: set-long-name
-      run: |
-        case "${{ inputs.build_type }}" in
-          sp)
-            echo "long-name=full_sp_debug" >> $GITHUB_ENV
-            ;;
-          dbg)
-            echo "long-name=full_debug" >> $GITHUB_ENV
-            ;;
-          fpe)
-            echo "long-name=debug_nopack_fpe" >> $GITHUB_ENV
-            ;;
-          opt)
-            echo "long-name=release" >> $GITHUB_ENV
-            ;;
-          cov)
-            echo "long-name=coverage" >> $GITHUB_ENV
-            ;;
-          valg)
-            echo "long-name=valgrind" >> $GITHUB_ENV
-            ;;
-          csm)
-            echo "long-name=compute_sanitizer_memcheck" >> $GITHUB_ENV
-            ;;
-          css)
-            echo "long-name=compute_sanitizer_synccheck" >> $GITHUB_ENV
-            ;;
-          csr)
-            echo "long-name=compute_sanitizer_racecheck" >> $GITHUB_ENV
-            ;;
-          csi)
-            echo "long-name=compute_sanitizer_initcheck" >> $GITHUB_ENV
-            ;;
-          *)
-            echo "Invalid build_type: ${{ inputs.build_type }}"
-            exit 1
-            ;;
-        esac
     - name: Print build specs
       run: |
         echo "Testing EAMxx standalone, for the following configuration:"
-        echo "  testing type: ${{ inputs.run-type }}"
+        echo "  testing type: ${{ inputs.run_type }}"
         echo "  build type  : ${{ inputs.build_type }}"
-        echo "  compiler    : ${{ inputs.compiler }}"
-        echo "  device      : ${{ inputs.device }}"
+        echo "  machine     : ${{ inputs.machine }}"
     - name: Run test-all-scream
       run: |
         cd components/eamxx
-        if [ "${{ inputs.run-type }}" = "nightly" ]; then
-          ./scripts/test-all-scream -m ghci-${{ inputs.device }} -t ${{inputs.build_type}} --baseline-dir AUTO -c EKAT_DISABLE_TPL_WARNINGS=ON -s
-        elif [ "${{ inputs.run-type }}" = "generate" ]; then 
-          ./scripts/test-all-scream -m ghci-${{ inputs.device }} -t ${{inputs.build_type}} --baseline-dir AUTO -c EKAT_DISABLE_TPL_WARNINGS=ON -g
+        if [ "${{ inputs.run_type }}" = "nightly" ]; then
+          ./scripts/test-all-scream -m ${{ inputs.machine }} -t ${{inputs.build_type}} --baseline-dir AUTO -c EKAT_DISABLE_TPL_WARNINGS=ON -s
+        elif [ "${{ inputs.run_type }}" = "generate" ]; then 
+          ./scripts/test-all-scream -m ${{ inputs.machine }} -t ${{inputs.build_type}} --baseline-dir AUTO -c EKAT_DISABLE_TPL_WARNINGS=ON -g
         else
-          ./scripts/test-all-scream -m ghci-${{ inputs.device }} -t ${{inputs.build_type}} --baseline-dir AUTO -c EKAT_DISABLE_TPL_WARNINGS=ON
+          ./scripts/test-all-scream -m ${{ inputs.machine }} -t ${{inputs.build_type}} --baseline-dir AUTO -c EKAT_DISABLE_TPL_WARNINGS=ON
         fi
     - name: Upload ctest logs
       if: always()
       uses: actions/upload-artifact@v3
       with:
         name: log-files-${{ inputs.build_type }}
-        path: components/eamxx/ctest-build/${{ env.long-name }}/Testing/Temporary/Last*.log
+        path: components/eamxx/ctest-build/*/Testing/Temporary/Last*.log
       env:
         NODE_EXTRA_CA_CERTS: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem


### PR DESCRIPTION
* Change device->machine
* Do not validate build type and machine
* Do away with long-name for tests